### PR TITLE
Removed php @ warning suppression

### DIFF
--- a/src/SimpleValidator/Validator.php
+++ b/src/SimpleValidator/Validator.php
@@ -231,7 +231,7 @@ class Validator {
                     /**
                      * Handle anonymous functions
                      */
-                    if (@get_class($closure) == 'Closure') {
+                    if(is_object($example) && get_class($example) == 'Closure') {
                         $refl_func = new \ReflectionFunction($closure);
                         $validation = $refl_func->invokeArgs($params);
                     }/**

--- a/src/SimpleValidator/Validator.php
+++ b/src/SimpleValidator/Validator.php
@@ -231,7 +231,7 @@ class Validator {
                     /**
                      * Handle anonymous functions
                      */
-                    if(is_object($example) && get_class($example) == 'Closure') {
+                    if(is_object($closure) && get_class($closure) == 'Closure') {
                         $refl_func = new \ReflectionFunction($closure);
                         $validation = $refl_func->invokeArgs($params);
                     }/**


### PR DESCRIPTION
Anonymous function handling was causing massive warnings in our API logs:
Severity: Warning  --> get_class() expects parameter 1 to be object, string given 

get_class can only be used on objects so it is quite safe to first check if we have an object. Otherwise E_WARNINGS are thrown.